### PR TITLE
feat: Implement foundational C++ logic for Dual Output feature

### DIFF
--- a/frontend/OBSApp.hpp
+++ b/frontend/OBSApp.hpp
@@ -67,8 +67,8 @@ private:
 	obs_video_info vertical_ovi;
 
 	bool dualOutputActive = false;
-	obs_source_t *current_horizontal_scene = nullptr; // Added for Dual Output
-	obs_source_t *current_vertical_scene = nullptr;   // Added for Dual Output
+	obs_source_t *current_horizontal_scene = nullptr;
+	obs_source_t *current_vertical_scene = nullptr;
 
 	// Dual Output Streaming
 	obs_service_t *horizontal_stream_service = nullptr;
@@ -234,6 +234,8 @@ public slots:
 
 signals:
 	void StyleChanged();
+	void horizontalSceneChanged(obs_source_t *new_scene); // Added for Dual Output
+	void verticalSceneChanged(obs_source_t *new_scene);   // Added for Dual Output
 };
 
 int GetAppConfigPath(char *path, size_t size, const char *name);

--- a/frontend/utility/AdvancedOutput.hpp
+++ b/frontend/utility/AdvancedOutput.hpp
@@ -43,5 +43,14 @@ struct AdvancedOutput : BasicOutputHandler {
 	virtual bool StreamingActive() const override;
 	virtual bool RecordingActive() const override;
 	virtual bool ReplayBufferActive() const override;
+
+	// Vertical Output Control
+	virtual bool StartVerticalStreaming(obs_service_t *service) override;
+	virtual void StopVerticalStreaming(bool force = false) override;
+	virtual bool VerticalStreamingActive() const override;
+	// virtual bool StartVerticalRecording() override; // If implementing
+	// virtual void StopVerticalRecording(bool force = false) override; // If implementing
+	// virtual bool VerticalRecordingActive() const override; // If implementing
+
 	bool allowsMultiTrack();
 };

--- a/frontend/utility/BasicOutputHandler.hpp
+++ b/frontend/utility/BasicOutputHandler.hpp
@@ -59,6 +59,15 @@ struct BasicOutputHandler {
 	OBSSignal streamDelayStarting;
 	OBSSignal streamStopping;
 	OBSSignal recordStopping;
+	// Vertical Output Signals
+	OBSSignal startVerticalStreaming;
+	OBSSignal stopVerticalStreaming;
+	OBSSignal verticalStreamDelayStarting; // If vertical stream has independent delay
+	OBSSignal verticalStreamStopping;
+	// OBSSignal startVerticalRecording; // If implementing vertical recording
+	// OBSSignal stopVerticalRecording;  // If implementing vertical recording
+	// OBSSignal verticalRecordStopping; // If implementing vertical recording
+	// OBSSignal verticalRecordFileChanged; // If implementing vertical recording
 	OBSSignal recordFileChanged;
 	OBSSignal replayBufferStopping;
 	OBSSignal replayBufferSaved;
@@ -81,6 +90,15 @@ struct BasicOutputHandler {
 	virtual bool RecordingActive() const = 0;
 	virtual bool ReplayBufferActive() const { return false; }
 	virtual bool VirtualCamActive() const;
+
+	// Vertical Output Control
+	virtual bool StartVerticalStreaming(obs_service_t *service) = 0;
+	virtual void StopVerticalStreaming(bool force = false) = 0;
+	virtual bool VerticalStreamingActive() const = 0;
+	// TODO: Add virtual functions for vertical recording if/when fully implemented
+	// virtual bool StartVerticalRecording() = 0;
+	// virtual void StopVerticalRecording(bool force = false) = 0;
+	// virtual bool VerticalRecordingActive() const = 0;
 
 	virtual void Update() = 0;
 	virtual void SetupOutputs() = 0;

--- a/frontend/utility/SimpleOutput.hpp
+++ b/frontend/utility/SimpleOutput.hpp
@@ -5,9 +5,18 @@
 struct SimpleOutput : BasicOutputHandler {
 	OBSEncoder audioStreaming;
 	OBSEncoder videoStreaming;
+
+	// Vertical Stream Encoders (Simple Mode)
+	OBSEncoder videoStreaming_v;
+	// Audio for vertical stream will use main audioStreaming or audioArchive if VOD track is different
+	// No separate audio encoder object needed here unless audio processing differs significantly.
+
 	OBSEncoder audioRecording;
 	OBSEncoder audioArchive;
 	OBSEncoder videoRecording;
+	// Vertical Recording Encoders (Simple Mode)
+	// OBSEncoder videoRecording_v; // if vertical recording is added
+	// OBSEncoder audioRecording_v; // if vertical recording is added
 	OBSEncoder audioTrack[MAX_AUDIO_MIXES];
 
 	std::string videoEncoder;
@@ -60,4 +69,12 @@ struct SimpleOutput : BasicOutputHandler {
 	virtual bool StreamingActive() const override;
 	virtual bool RecordingActive() const override;
 	virtual bool ReplayBufferActive() const override;
+
+	// Vertical Output Control
+	virtual bool StartVerticalStreaming(obs_service_t *service) override;
+	virtual void StopVerticalStreaming(bool force = false) override;
+	virtual bool VerticalStreamingActive() const override;
+	// virtual bool StartVerticalRecording() override; // If implementing
+	// virtual void StopVerticalRecording(bool force = false) override; // If implementing
+	// virtual bool VerticalRecordingActive() const override; // If implementing
 };

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -307,6 +307,9 @@ private:
 public slots:
 	void UpdatePatronJson(const QString &text, const QString &error);
 	void UpdateEditMenu();
+	// Slots for OBSApp signals
+	void HandleHorizontalSceneChanged(obs_source_t *new_scene);
+	void HandleVerticalSceneChanged(obs_source_t *new_scene);
 
 public slots: // Added for Dual Output
 	void SetHorizontalPreviewActive();

--- a/frontend/widgets/OBSBasicStatusBar.hpp
+++ b/frontend/widgets/OBSBasicStatusBar.hpp
@@ -61,9 +61,23 @@ private:
 	float lastCongestion = 0.0f;
 
 	QPointer<QTimer> refreshTimer;
-	QPointer<QTimer> messageTimer;
+	QPointer<QTimer> messageTimer; // For general messages
+	QPointer<QTimer> verticalStreamTimer; // For updating vertical stream time
 
-	obs_output_t *GetOutput();
+	// Vertical Stream specific members
+	OBSWeakOutputAutoRelease verticalStreamOutput_; // Suffix to avoid clash if base class uses it
+	std::vector<OBSSignal> verticalStreamSigs;
+	bool verticalStreamingActive_ = false;
+	bool verticalStreamDisconnected_ = false;
+	int verticalStreamTotalSeconds_ = 0;
+	int verticalStreamReconnectTimeout_ = 0;
+	int verticalStreamRetries_ = 0;
+	uint64_t verticalStreamLastBytesSent_ = 0;
+	uint64_t verticalStreamLastBytesSentTime_ = 0;
+	int verticalStreamSecondsCounter_ = 0; // For periodic bandwidth update
+	// Add pixmaps for vertical stream status if different icons are desired
+
+	obs_output_t *GetOutput(); // This likely refers to the main (horizontal) stream output
 
 	void Activate();
 	void Deactivate();
@@ -104,4 +118,12 @@ public:
 	void RecordingUnpaused();
 
 	void ReconnectClear();
+
+public slots: // Slots for Vertical Streaming
+	void VerticalStreamStarted(obs_output_t *output);
+	void VerticalStreamStopped(int code, QString last_error);
+	void UpdateVerticalStreamTime();
+	void VerticalStreamDelayStarting(int seconds);
+	void VerticalStreamStopping();
+	// TODO: Add slots for vertical recording status if implemented
 };


### PR DESCRIPTION
This commit includes extensive C++ groundwork for the Dual Output feature, covering configuration, scene management, output handling, and status indication.

Key changes:
- Core state management in OBSApp for dual output mode.
- Configuration persistence for vertical video settings (resolution, FPS) and selected vertical scene.
- C++ logic in OBSBasicSettings for loading/saving vertical output settings (Video tab, Simple Output tabs, Advanced Output tabs for Stream/Record). This assumes corresponding UI elements will be added to .ui files.
- Scene switching logic in OBSBasic (SetCurrentScene) updated to be aware of active horizontal/vertical preview panes.
- Signals in OBSApp for horizontal/vertical scene changes, with handlers in OBSBasic.
- BasicOutputHandler extended with signals, state variables, and pure virtual functions for vertical stream/recording status.
- SimpleOutput and AdvancedOutput updated to handle vertical stream start/stop and status, and to setup vertical encoders/outputs.
- OBSBasicStatusBar updated with C++ logic for vertical stream status display (pending UI element creation).
- Global callbacks for vertical stream events added to BasicOutputHandler.cpp.

Note: This feature is NOT YET COMPLETE. Critical UI elements are missing and need to be manually created in OBSBasic.ui, OBSBasicSettings.ui, and StatusBarWidget.ui. Deep libobs verification for the second video pipeline is also pending.

Refer to AGENTS.MD for a detailed status, list of affected files, and comprehensive TODOs for feature completion.