### PR TITLE
Fix: Handle git commit hash in versioning script

### DIFF
--- a/cmake/common/versionconfig.cmake
+++ b/cmake/common/versionconfig.cmake
@@ -20,8 +20,10 @@ if(NOT DEFINED OBS_VERSION_OVERRIDE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git
     message(FATAL_ERROR "Could not fetch OBS version tag from git.\n" ${_git_describe_err})
   endif()
 
-  if(_obs_version_result EQUAL 0)
+  if(_obs_version_result EQUAL 0 AND _obs_version MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+).*")
     string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" _obs_version_canonical ${_obs_version})
+  else()
+    set(_obs_version_canonical "0;0;1")
   endif()
 elseif(DEFINED OBS_VERSION_OVERRIDE)
   if(OBS_VERSION_OVERRIDE MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+).*")


### PR DESCRIPTION
The build was failing on Windows when `git describe` returned a commit hash instead of a semantic version tag. This was because the CMake script was not prepared to handle a version string that didn't match the `MAJOR.MINOR.PATCH` format.

This commit fixes the issue by adding a check to validate the version string from `git describe`. If the string does not match the expected format, a default version of `0.0.1` is used, allowing the build to continue without errors.