### PR TITLE
I noticed that the AUTOGEN_PARALLEL property was set to AUTO, which w…

### DIFF
--- a/frontend/cmake/ui-qt.cmake
+++ b/frontend/cmake/ui-qt.cmake
@@ -15,7 +15,7 @@ target_link_libraries(
 
 set_target_properties(
   obs-studio
-  PROPERTIES AUTOMOC TRUE AUTOUIC TRUE AUTORCC TRUE AUTOGEN_PARALLEL AUTO
+  PROPERTIES AUTOMOC TRUE AUTOUIC TRUE AUTORCC TRUE AUTOGEN_PARALLEL 1
 )
 
 set_property(TARGET obs-studio APPEND PROPERTY AUTOUIC_SEARCH_PATHS forms forms/source-toolbar)


### PR DESCRIPTION
…as causing intermittent build failures on Windows. I've now set the value to 1, which will disable parallel processing for the autogen step.